### PR TITLE
Fixing some remaining riak-admin relics

### DIFF
--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -692,7 +692,7 @@ repair_2i(Args) ->
             error;
         {error, Reason} ->
             io:format("Error: ~p\n", [Reason]),
-            io:format("Usage: riak-admin repair-2i [--speed [1-100]] <Idx> ...\n", []),
+            io:format("Usage: riak admin repair-2i [--speed [1-100]] <Idx> ...\n", []),
             io:format("Speed defaults to 100 (full speed)\n", []),
             io:format("If no partitions are given, all partitions in the\n"
                       "node are repaired\n", []),

--- a/src/riak_kv_stat_bc.erl
+++ b/src/riak_kv_stat_bc.erl
@@ -23,7 +23,7 @@
 
 %% @doc riak_kv_stat_bc is a module that maps the new riak_kv_stats metrics
 %% to the old set of stats. It exists to maintain backwards compatibility for
-%% those using the `/stats' endpoint and `riak-admin status'. This module
+%% those using the `/stats' endpoint and `riak admin status'. This module
 %% should be considered soon to be deprecated and temporary.
 %%
 %%      Legacy stats:


### PR DESCRIPTION
Fixing some remaining riak-admin relics that should be `riak admin`